### PR TITLE
add the required zmk config for deep sleep wake

### DIFF
--- a/zmk-config-caldera/config/boards/shields/caldera/caldera.dtsi
+++ b/zmk-config-caldera/config/boards/shields/caldera/caldera.dtsi
@@ -28,7 +28,7 @@ RC(5,0) RC(5,1) RC(5,2) RC(5,3) RC(5,4) RC(5,5)                 RC(5,6) RC(5,7) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
-
+        wakeup-source;
         diode-direction = "col2row";
         row-gpios
             = <&pro_micro 21 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)> // Row A from the schematic file


### PR DESCRIPTION
Once the keyboard goes into deep sleep, it won't wake up by keypress unless we have this option enabled for the kscan.